### PR TITLE
fix: ssh user dir permissions

### DIFF
--- a/libvirt/ansible/playbook.yml
+++ b/libvirt/ansible/playbook.yml
@@ -98,6 +98,16 @@
         loop: '{{ additional_users }}'
         when: item.authorized_key | default(false, true)
         become: yes
+
+      - name: fix ssh user dir permissions
+        ansible.builtin.file:
+          path: '/home/{{ item.name }}/.ssh'
+          state: directory
+          recurse: yes
+          owner: '{{ item.name }}'
+          group: '{{ item.name }}'
+        loop: '{{ additional_users }}'
+        become: yes
       when: additional_users | default(false, true)
       # endblock add additional users
 


### PR DESCRIPTION
Login was impossible as an `additional_user` because all the files in the .ssh directory of the user were created and owned by the root user